### PR TITLE
Add a bit more flexibility

### DIFF
--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -76,18 +76,16 @@ class BasinHopping:
                     pass
             # Perform local minimisation
             if self.opt_method == 'scipy':
-                print('Using scipy for geometry')
                 min_position, energy, results_dict = \
                     lbfgs.minimise(func_grad=self.potential.function_gradient,
                                 initial_position=coords.position,
                                 bounds=coords.bounds,
                                 conv_crit=conv_crit)
             elif self.opt_method == 'psi4':
-                print('Using psi4 for geometry')
                 if not isinstance(self.potential, DensityFunctionalTheory):
                     raise ValueError("Psi4 optimisation method requires DFT potential")
                 min_position, energy, results_dict = \
-                psi4_internal.psi4_minimise(self.potential,
+                psi4_internal.minimise(self.potential,
                                 initial_position=coords.position,
                                 conv_crit=conv_crit)
             else:
@@ -127,14 +125,12 @@ class BasinHopping:
                                     conv_crit: float) -> float:
         """ Generate the initial minimum and set its energy and position """
         if self.opt_method == 'scipy':
-            print('Using scipy for geometry')
             min_position, energy, results_dict = \
                 lbfgs.minimise(func_grad=self.potential.function_gradient,
                             initial_position=coords.position,
                             bounds=coords.bounds,
                             conv_crit=conv_crit)
         elif self.opt_method == 'psi4':
-            print('Using psi4 for geometry')
             if not isinstance(self.potential, DensityFunctionalTheory):
                 raise ValueError("Psi4 optimisation method requires DFT potential")
             min_position, energy, results_dict = \

--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -46,6 +46,7 @@ class BasinHopping:
         self.potential = potential
         self.similarity = similarity
         self.step_taking = step_taking
+        self.opt_method = opt_method
 
     def run(self, coords: type, n_steps: int, conv_crit: float,
             temperature: float) -> None:
@@ -72,13 +73,13 @@ class BasinHopping:
                 except:
                     pass
             # Perform local minimisation
-            if opt_method == 'scipy':
+            if self.opt_method == 'scipy':
                 min_position, energy, results_dict = \
                     lbfgs.minimise(func_grad=self.potential.function_gradient,
                                 initial_position=coords.position,
                                 bounds=coords.bounds,
                                 conv_crit=conv_crit)
-            elif opt_method == 'psi4':
+            elif self.opt_method == 'psi4':
                 if not isinstance(self.potential, DensityFunctionalTheory):
                     raise ValueError("Psi4 optimisation method requires DFT potential")
                 psi4_internal

--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -63,6 +63,8 @@ class BasinHopping:
             # Test for and remove atom clashes if density functional theory
             if isinstance(self.potential, DensityFunctionalTheory):
                 coords.remove_atom_clashes(self.potential.force_field)
+            elif isinstance(coords, MolecularCoordinates):
+                coords.remove_atom_clashes(self.potential.force_field)
             elif isinstance(coords, AtomicCoordinates):
                 coords.remove_atom_clashes()
             # Perform local minimisation

--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -63,10 +63,13 @@ class BasinHopping:
             # Test for and remove atom clashes if density functional theory
             if isinstance(self.potential, DensityFunctionalTheory):
                 coords.remove_atom_clashes(self.potential.force_field)
-            elif isinstance(coords, MolecularCoordinates):
-                coords.remove_atom_clashes(self.potential.force_field)
+            # elif isinstance(coords, MolecularCoordinates):
+            #     coords.remove_atom_clashes(self.potential.force_field)
             elif isinstance(coords, AtomicCoordinates):
-                coords.remove_atom_clashes()
+                try:
+                    coords.remove_atom_clashes()
+                except:
+                    pass
             # Perform local minimisation
             min_position, energy, results_dict = \
                 lbfgs.minimise(func_grad=self.potential.function_gradient,

--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -43,7 +43,6 @@ class BasinHopping:
                  step_taking: type,
                  opt_method: str = 'scipy',) -> None:
         
-        print('Initialising BasinHopping')
         self.ktn = ktn
         self.potential = potential
         self.similarity = similarity
@@ -67,13 +66,11 @@ class BasinHopping:
             # Test for and remove atom clashes if density functional theory
             if isinstance(self.potential, DensityFunctionalTheory):
                 coords.remove_atom_clashes(self.potential.force_field)
-            # elif isinstance(coords, MolecularCoordinates):
-            #     coords.remove_atom_clashes(self.potential.force_field)
             elif isinstance(coords, AtomicCoordinates):
                 try:
                     coords.remove_atom_clashes()
                 except:
-                    pass
+                    pass # TODO: this was giving me an error with the MACE
             # Perform local minimisation
             if self.opt_method == 'scipy':
                 min_position, energy, results_dict = \

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -15,7 +15,6 @@ def minimise(potential,
     basis = calc.parameters['basis']
     calc.set_psi4()
     
-    
     # using only force convergence for now
     e, hist = psi4.optimize(f'{method}/{basis}',
                     molecule=calc.molecule,

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -3,6 +3,7 @@
 from nptyping import NDArray
 import numpy as np
 from ase.units import Bohr
+import contextlib
 
 def minimise(potential,
              initial_position: NDArray,
@@ -22,15 +23,16 @@ def minimise(potential,
     
     # using only force convergence for now
     try:
-        e, hist = psi4.opt(f'{method}/{basis}',
-                        molecule=calc.molecule,
-                        return_history=True,
-                        optimizer_keywords={"MAX_FORCE_G_CONVERGENCE": conv_crit,
-                            "GEOM_MAXITER": n_steps,
-                            "MAX_ENERGY_G_CONVERGENCE": 1e2,
-                            "RMS_FORCE_G_CONVERGENCE": 1e2,
-                            "MAX_DISP_G_CONVERGENCE": 1e2,
-                            "RMS_DISP_G_CONVERGENCE": 1e2})
+        with contextlib.redirect_stdout(None): # silence chatty Psi4
+            e, hist = psi4.opt(f'{method}/{basis}',
+                            molecule=calc.molecule,
+                            return_history=True,
+                            optimizer_keywords={"MAX_FORCE_G_CONVERGENCE": conv_crit,
+                                "GEOM_MAXITER": n_steps,
+                                "MAX_ENERGY_G_CONVERGENCE": 1e2,
+                                "RMS_FORCE_G_CONVERGENCE": 1e2,
+                                "MAX_DISP_G_CONVERGENCE": 1e2,
+                                "RMS_DISP_G_CONVERGENCE": 1e2})
     
         min_coords = hist['coordinates'][-1].flatten()*Bohr
         results_dict = {'task': None,

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -1,6 +1,10 @@
-"Use internal Optking routines to optimise geometry if using Psi4 for DFT."
+"Use fast internal Optking routine to optimise geometry if doing DFT with Psi4."
 
 from nptyping import NDArray
+import numpy as np
+from psi4.driver import OptimizationConvergenceError
+from psi4.driver.p4util.exceptions import SCFConvergenceError
+from ase.units import Bohr
 
 def minimise(potential,
              initial_position: NDArray,
@@ -14,22 +18,33 @@ def minimise(potential,
     method = calc.parameters['method']
     basis = calc.parameters['basis']
     calc.set_psi4()
+    calc.psi4.core.set_output_file(calc.label + '.dat',
+                                       False)
     
     # using only force convergence for now
-    e, hist = psi4.optimize(f'{method}/{basis}',
-                    molecule=calc.molecule,
-                    return_history=True,
-                    optimizer_keywords={"MAX_FORCE_G_CONVERGENCE": conv_crit,
-                        "GEOM_MAXITER": n_steps,
-                        "MAX_ENERGY_G_CONVERGENCE": 1e2,
-                        "RMS_FORCE_G_CONVERGENCE": 1e2,
-                        "MAX_DISP_G_CONVERGENCE": 1e2,
-                        "RMS_DISP_G_CONVERGENCE": 1e2})
+    try:
+        e, hist = psi4.opt(f'{method}/{basis}',
+                        molecule=calc.molecule,
+                        return_history=True,
+                        optimizer_keywords={"MAX_FORCE_G_CONVERGENCE": conv_crit,
+                            "GEOM_MAXITER": n_steps,
+                            "MAX_ENERGY_G_CONVERGENCE": 1e2,
+                            "RMS_FORCE_G_CONVERGENCE": 1e2,
+                            "MAX_DISP_G_CONVERGENCE": 1e2,
+                            "RMS_DISP_G_CONVERGENCE": 1e2})
     
-    min_coords = hist['coordinates'][-1]
-    # dummy to mimic scipy results_dict
-    results_dict = {'task': None,
-                    'warnflag': 0,
+        min_coords = hist['coordinates'][-1].flatten()*Bohr
+        results_dict = {'task': None,
+                        'warnflag': 0,
+                    }
+        
+    except (SCFConvergenceError, OptimizationConvergenceError):
+        print("Optimisation failed to converge")
+        min_coords = np.full((initial_position.size), np.nan, dtype=float)
+        e = np.nan
+        # dummy to mimic scipy results_dict
+        results_dict = {'task': None,
+                        'warnflag': 1,
                     }
     return min_coords, e, results_dict
     

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -1,0 +1,31 @@
+"Use internal Optking routines to optimise geometry if using Psi4 for DFT."
+
+from nptyping import NDArray
+
+def minimise(potential,
+             initial_position: NDArray,
+             conv_crit: float = 1e-6,
+             n_steps: int = 50,):
+
+    atoms = potential.atoms
+    atoms.set_positions(initial_position.reshape(-1, 3))
+    calc = potential.atoms.calc
+    psi4 = calc.psi4
+    method = calc.parameters['method']
+    basis = calc.parameters['basis']
+    calc.set_psi4()
+    
+    
+    # using only force convergence for now
+    e, hist = psi4.optimize(f'{method}/{basis}',
+                    molecule=calc.molecule,
+                    return_history=True,
+                    optimizer_keywords={"MAX_FORCE_G_CONVERGENCE": conv_crit,
+                        "GEOM_MAXITER": n_steps,
+                        "MAX_ENERGY_G_CONVERGENCE": 1e2,
+                        "RMS_FORCE_G_CONVERGENCE": 1e2,
+                        "MAX_DISP_G_CONVERGENCE": 1e2,
+                        "RMS_DISP_G_CONVERGENCE": 1e2})
+    
+    return e, hist
+    

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -26,5 +26,10 @@ def minimise(potential,
                         "MAX_DISP_G_CONVERGENCE": 1e2,
                         "RMS_DISP_G_CONVERGENCE": 1e2})
     
-    return e, hist
+    min_coords = hist['coordinates'][-1]
+    # dummy to mimic scipy results_dict
+    results_dict = {'task': None,
+                    'warnflag': 0,
+                    }
+    return min_coords, e, results_dict
     

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -32,7 +32,8 @@ def minimise(potential,
                                 "MAX_ENERGY_G_CONVERGENCE": 1e2,
                                 "RMS_FORCE_G_CONVERGENCE": 1e2,
                                 "MAX_DISP_G_CONVERGENCE": 1e2,
-                                "RMS_DISP_G_CONVERGENCE": 1e2})
+                                "RMS_DISP_G_CONVERGENCE": 1e2,
+                                "intrafrag_step_limit_max": 0.25}) # last one to improve convergence behaviour
     
         min_coords = hist['coordinates'][-1].flatten()*Bohr
         results_dict = {'task': None,

--- a/src/topsearch/minimisation/psi4_internal.py
+++ b/src/topsearch/minimisation/psi4_internal.py
@@ -2,15 +2,14 @@
 
 from nptyping import NDArray
 import numpy as np
-from psi4.driver import OptimizationConvergenceError
-from psi4.driver.p4util.exceptions import SCFConvergenceError
 from ase.units import Bohr
 
 def minimise(potential,
              initial_position: NDArray,
              conv_crit: float = 1e-6,
              n_steps: int = 50,):
-
+    from psi4.driver import OptimizationConvergenceError
+    from psi4.driver.p4util.exceptions import SCFConvergenceError
     atoms = potential.atoms
     atoms.set_positions(initial_position.reshape(-1, 3))
     calc = potential.atoms.calc

--- a/src/topsearch/potentials/dft.py
+++ b/src/topsearch/potentials/dft.py
@@ -8,6 +8,7 @@ from ase import Atoms
 from ase.units import Hartree, Bohr
 import warnings
 import traceback
+import contextlib
 from .potential import Potential
 
 
@@ -118,8 +119,9 @@ class DensityFunctionalTheory(Potential):
         method = calc.parameters['method']
         basis = calc.parameters['basis']
         try:
-            hess = calc.psi4.driver.hessian(f'{method}/{basis}',
-                                            molecule=calc.molecule,).to_array()
+            with contextlib.redirect_stdout(None): # silence chatty Psi4
+                hess = calc.psi4.driver.hessian(f'{method}/{basis}',
+                                                molecule=calc.molecule,).to_array()
             hess *= Bohr**2/Hartree
         except Exception:
             traceback.print_exc()

--- a/src/topsearch/potentials/dft.py
+++ b/src/topsearch/potentials/dft.py
@@ -5,6 +5,9 @@ import numpy as np
 from nptyping import NDArray
 from ase.calculators.psi4 import Psi4
 from ase import Atoms
+from ase.units import Hartree, Bohr
+import warnings
+import traceback
 from .potential import Potential
 
 
@@ -99,3 +102,27 @@ class DensityFunctionalTheory(Potential):
         except Exception:
             return np.full((position.size), np.inf, dtype=float)
         return -1.0 * np.array(forces.tolist())
+    
+    def hessian(self, position: NDArray,
+                displacement: float = 1e-4) -> NDArray:
+        """ Override numerical hessian calculation with internal analytic version for DFT."""
+        
+        if displacement != 1e-4:
+            warnings.warn("Displacement is not used in DFT hessian calculation, ignoring input.",
+                          UserWarning)
+        self.atoms.set_positions(position.reshape(-1, 3))
+        calc = self.atoms.calc
+        calc.set_psi4()
+        calc.psi4.core.set_output_file(calc.label + '.dat',
+                                       False)
+        method = calc.parameters['method']
+        basis = calc.parameters['basis']
+        try:
+            hess = calc.psi4.driver.hessian(f'{method}/{basis}',
+                                            molecule=calc.molecule,).to_array()
+            hess *= Bohr**2/Hartree
+        except Exception:
+            traceback.print_exc()
+            hess = np.full((position.size, position.size), np.inf, dtype=float)
+        
+        return hess

--- a/src/topsearch/potentials/ml_potentials.py
+++ b/src/topsearch/potentials/ml_potentials.py
@@ -23,7 +23,9 @@ class MachineLearningPotential(Potential):
     """
 
     def __init__(self, atom_labels: list,
-                 calculator_type: str = 'torchani') -> None:
+                 calculator_type: str = 'torchani',
+                 model: str = 'MACE_model_swa.model',
+                 device: str = 'cpu') -> None:
         self.atomistic = True
         self.calculator_type = calculator_type
         self.atom_labels = atom_labels
@@ -42,8 +44,8 @@ class MachineLearningPotential(Potential):
         elif self.calculator_type == 'mace':
             from mace.calculators import MACECalculator
             self.atoms.calc = \
-                MACECalculator(model_paths='MACE_model_swa.model',
-                               device='cpu')
+                MACECalculator(model_paths=model,
+                               device=device)
 
     def function(self, position: NDArray) -> float:
         """ Compute the electronic potential energy """

--- a/src/topsearch/potentials/ml_potentials.py
+++ b/src/topsearch/potentials/ml_potentials.py
@@ -77,10 +77,15 @@ class MachineLearningPotential(Potential):
         """ Compute the electronic potential energy and its forces """
         self.atoms.set_positions(position.reshape(-1, 3))
 
-        if self.calculator_type in ['mace', 'aimnet2']:
+        if self.calculator_type == 'mace':
             # Calculate energy and forces using Psi4
-            energy = self.atoms.get_potential_energy()
             forces = self.atoms.get_forces().flatten()
+            energy = self.atoms.get_potential_energy()
+            gradient = -1.0 * np.array(forces.tolist())
+        elif self.calculator_type == 'aimnet2':
+            self.atoms.calc.calculate(self.atoms, properties=['energy', 'forces'])
+            forces = self.atoms.get_forces().flatten()
+            energy = self.atoms.get_potential_energy()
             gradient = -1.0 * np.array(forces.tolist())
         elif self.calculator_type == 'torchani':
             import torch

--- a/src/topsearch/sampling/exploration.py
+++ b/src/topsearch/sampling/exploration.py
@@ -60,7 +60,8 @@ class NetworkSampling:
                  double_ended_search: type,
                  similarity: type,
                  multiprocessing_on: bool = False,
-                 n_processes: int = None) -> None:
+                 n_processes: int = None,
+                 output_level: int = 0) -> None:
         self.ktn = ktn
         self.coords = coords
         self.global_optimiser = global_optimiser
@@ -69,6 +70,7 @@ class NetworkSampling:
         self.similarity = similarity
         self.multiprocessing_on = multiprocessing_on
         self.n_processes = n_processes
+        self.output_level = output_level
 
     # OVERALL LANDSCAPE EXPLORATION
 
@@ -187,7 +189,7 @@ class NetworkSampling:
         for ts_search_number, ts_candidate in enumerate(positions, start=1):
             local_coords.position = ts_candidate
             ts_coords, e_ts, min_plus, e_plus, min_minus, e_minus, neg_eig = \
-                self.single_ended_search.run(local_coords)
+                self.single_ended_search.run(local_coords, tag=ts_search_number)
             # Check search was successful
             if ts_coords is not None:
                 with open('logfile', 'a', encoding="utf-8") as outfile:

--- a/src/topsearch/transition_states/hybrid_eigenvector_following.py
+++ b/src/topsearch/transition_states/hybrid_eigenvector_following.py
@@ -62,7 +62,9 @@ class HybridEigenvectorFollowing:
                  min_uphill_step_size: float = 1e-7,
                  max_uphill_step_size: float = 1.0,
                  positive_eigenvalue_step: float = 0.1,
-                 eigenvalue_conv_crit: float = 1e-5) -> None:
+                 eigenvalue_conv_crit: float = 1e-5,
+                 output_level: int = 0,
+                 tag: str = '') -> None:
         self.potential = potential
         self.ts_conv_crit = ts_conv_crit
         self.ts_steps = ts_steps
@@ -75,8 +77,9 @@ class HybridEigenvectorFollowing:
         self.eigenvector_bounds = None
         self.failure = None
         self.remove_trans_rot = None
+        self.output_level = output_level
 
-    def run(self, coords: type) -> tuple:
+    def run(self, coords: type, tag: str = '') -> tuple:
         """ Perform a single-ended transition state search starting from 
             coords. Returns the information about transition states
             and their connected minima that is needed for testing similarity
@@ -120,6 +123,9 @@ class HybridEigenvectorFollowing:
             # Reset appropriate eigenvector bounds
             lower_bounds, upper_bounds = coords.active_bounds()
             self.update_eigenvector_bounds(lower_bounds, upper_bounds)
+            
+            if self.output_level > 0:
+                coords.write_xyz(f'coords_{tag}_{n_steps}.xyz')
             # Test for convergence to a transition state
             if self.test_convergence(coords.position, lower_bounds,
                                      upper_bounds):

--- a/src/topsearch/transition_states/nudged_elastic_band.py
+++ b/src/topsearch/transition_states/nudged_elastic_band.py
@@ -53,7 +53,9 @@ class NudgedElasticBand:
                  force_constant: float,
                  image_density: float,
                  max_images: int,
-                 neb_conv_crit: float) -> None:
+                 neb_conv_crit: float,
+                 output_level: int = 0,
+                 ) -> None:
         self.potential = potential
         self.force_constant = force_constant
         self.image_density = image_density
@@ -64,6 +66,7 @@ class NudgedElasticBand:
         self.n_images = None
         self.band_bounds = None
         self.neb_count = 0
+        self.output_level = output_level
 
     def run(self, coords1: type, coords2: NDArray, attempts: int = 0,
             permutation: NDArray = None) -> tuple[NDArray, NDArray]:
@@ -79,6 +82,10 @@ class NudgedElasticBand:
         candidates, positions = self.find_ts_candidates(band)
         # Return the transition state candidates and their positions
         self.neb_count += 1
+        if self.output_level > 0:
+            print(f'NEB {self.neb_count} found {len(candidates)} candidates')
+            np.savetxt(f'neb_ts_{self.neb_count}.txt', positions)
+            
         return candidates, positions
 
     def minimise_interpolation(self, band: NDArray) -> NDArray:
@@ -93,7 +100,10 @@ class NudgedElasticBand:
                            bounds=self.band_bounds,
                            conv_crit=self.neb_conv_crit)
         # Reshape into 2d array, one image per row
-        return np.reshape(optimised_band, (self.n_images, -1))
+        opt_band_reshape = np.reshape(optimised_band, (self.n_images, -1))
+        if self.output_level > 0:
+            np.savetxt(f'neb_min_{self.neb_count}.txt', opt_band_reshape)
+        return opt_band_reshape
 
     def update_image_density(self, attempts: int) -> None:
         """ Update the image density parameter """


### PR DESCRIPTION
A few small changes to add some flexibility:

- ability to specify device and model for MACE (e.g. can use `mps` for gpu evaluation on macs)
- option to use internal Psi4 geometry optimisations through introduction of a `opt_method` kwarg to BasinHopping (should be 3-5 times faster thanks to better wfn guesses between steps)
- Hessian evaluations with Psi4 now use internal Hessian routine (should be 3-5 times faster as well)
- added Aimnet2 support


Note: `remove_atom_clashes()` was giving me an error when using MACE models, so I lazily ignored this for now. Could fix at some point in future

all tests passing