### PR TITLE
Fix psi4 basin hopping by adding import

### DIFF
--- a/src/topsearch/global_optimisation/basin_hopping.py
+++ b/src/topsearch/global_optimisation/basin_hopping.py
@@ -5,7 +5,7 @@ from timeit import default_timer as timer
 import numpy as np
 from topsearch.data.kinetic_transition_network import KineticTransitionNetwork
 from topsearch.global_optimisation.perturbations import AtomicPerturbation, MolecularPerturbation, StandardPerturbation
-from topsearch.minimisation import lbfgs
+from topsearch.minimisation import lbfgs, psi4_internal
 from topsearch.data.coordinates import MolecularCoordinates, AtomicCoordinates, StandardCoordinates
 from topsearch.potentials.dft import DensityFunctionalTheory
 from topsearch.potentials.potential import Potential


### PR DESCRIPTION
I just pulled the latest version of the code `Commit b208aba` and tried running basin hopping with psi4. I get the error:
`Traceback (most recent call last):
  File "/home/vc381/Calculations/ibm-calculations/19012025-aidingLukeWithDFTLandscape/test/run_dft.py", line 9, in <module>
    from topsearch.global_optimisation.basin_hopping import BasinHopping
  File "/home/vc381/Calculations/ibm-calculations/dev/topography-searcher/src/topsearch/global_optimisation/basin_hopping.py", line 13, in <module>
    import psi4_internal
ModuleNotFoundError: No module named 'psi4_internal'
`

This is fixed by adding an extra import at the top, as: 
`from topsearch.minimisation import psi4_internal`

Minimisation runs fine after adding this import. 

To reproduce open the Archive attached, and run "python run.py".
[Archive.zip](https://github.com/user-attachments/files/18470471/Archive.zip)
